### PR TITLE
Fix the transaction export failure

### DIFF
--- a/src/main/java/com/infor/m3/xtendm3/maven/plugin/exporter/transformer/TransactionExtensionFactory.java
+++ b/src/main/java/com/infor/m3/xtendm3/maven/plugin/exporter/transformer/TransactionExtensionFactory.java
@@ -34,6 +34,9 @@ public class TransactionExtensionFactory implements ExtensionFactory {
 
   private List<ExtMIField> buildInputFields(List<TransactionFieldMetadata> inputFieldsMetadata) {
     List<ExtMIField> inputFields = new ArrayList<>();
+    if(inputFieldsMetadata == null || inputFieldsMetadata.isEmpty()) {
+      return inputFields;
+    }
     for (TransactionFieldMetadata fieldMetadata : inputFieldsMetadata) {
       inputFields.add(ExtMIField.builder()
         .name(fieldMetadata.getName())
@@ -48,6 +51,9 @@ public class TransactionExtensionFactory implements ExtensionFactory {
 
   private List<ExtMIField> buildOutputFields(List<TransactionFieldMetadata> outputFieldsMetadata) {
     List<ExtMIField> outputFields = new ArrayList<>();
+    if(outputFieldsMetadata == null || outputFieldsMetadata.isEmpty()) {
+      return outputFields;
+    }
     for (TransactionFieldMetadata fieldMetadata : outputFieldsMetadata) {
       outputFields.add(ExtMIField.builder()
         .name(fieldMetadata.getName())


### PR DESCRIPTION
Fix the bug where transaction export fails if there are no input fields or output fields.

Below are some of the examples of transaction metadata that fail because both input and output fields are mandatory.

metadataVersion: 1
apis:
  - name: EXT100MI
    transactions:
      - name: Get
        description: Get
        type: SINGLE
        inputs:
          - name: CONO
            description: Company
            length: 3
            type: NUMERIC
            mandatory: false
        outputs:

metadataVersion: 1
apis:
  - name: EXT100MI
    transactions:
      - name: Get
        description: Get
        type: SINGLE
        inputs:
        outputs:
          - name: CONO
            description: Company
            length: 3
            type: NUMERIC

metadataVersion: 1
apis:
  - name: EXT100MI
    transactions:
      - name: Get
        description: Get
        type: SINGLE

metadataVersion: 1
apis:
  - name: EXT100MI
    transactions:
      - name: Get
        description: Get
        type: SINGLE
        inputs:
        outputs:

